### PR TITLE
Fix the timing control to call workerProxy.updateFuncCode

### DIFF
--- a/streamlit_fesion/frontend/src/MyComponent.tsx
+++ b/streamlit_fesion/frontend/src/MyComponent.tsx
@@ -41,7 +41,7 @@ const MyComponent: React.VFC = () => {
     ]
   );
   useEffect(() => {
-    if (workerProxy == null || !workerProxy.isLoaded) {
+    if (workerProxy == null) {
       return;
     }
 
@@ -56,7 +56,7 @@ const MyComponent: React.VFC = () => {
       requirements: filterDepPackages,
     });
   }, [
-    workerProxy,
+    // `workerProxy` is excluded from the deps so that this function is not called just reacting the initialization of `workerProxy`.
     imageFilterPyFuncName,
     imageFilterPyFuncDefCode,
     imageFilterDepPackagesJson,

--- a/streamlit_fesion/frontend/src/worker/fesion.worker.ts
+++ b/streamlit_fesion/frontend/src/worker/fesion.worker.ts
@@ -136,6 +136,11 @@ self.onmessage = async (event: MessageEvent<InMessage>): Promise<void> => {
       }
       case "updateFilterFunc": {
         const { funcName, funcDefPyCode, requirements } = data.data;
+        console.debug("updateFilterFunc", {
+          funcName,
+          funcDefPyCode,
+          requirements,
+        });
 
         // Load packages used in the user-defined filter function.
         await pyodide.loadPackagesFromImports(funcDefPyCode);


### PR DESCRIPTION
so that changing the filter function makes effect even before the worker is loaded.